### PR TITLE
Fix getLogs for Monad 100-block query limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ contracts/broadcast/
 # Web frontend
 web/node_modules/
 web/dist/
+web/.vite/

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -9,6 +9,12 @@ export const CONTRACTS = {
   wager: "0x8d4D9FD03242410261b2F9C0e66fE2131AE0459d" as const,
 };
 
+// Block where contracts were deployed — start scanning from here
+export const DEPLOY_BLOCK = 10710000n;
+
+// Monad testnet caps getLogs at 100 blocks per request
+export const MAX_LOG_RANGE = 100n;
+
 export const ERC8004 = {
   identity: "0x8004A818BFB912233c491871b3d84c89A494BD9e" as const,
   reputation: "0x8004B663056A597Dffe9eCcC1965A193B7388713" as const,

--- a/web/src/hooks/useMatchEvents.ts
+++ b/web/src/hooks/useMatchEvents.ts
@@ -1,9 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { publicClient } from "../viem";
 import { matchProofAbi } from "../abi/matchProof";
 import { CONTRACTS, USE_MOCK_DATA } from "../config";
 import { MOCK_MATCHES } from "../lib/mockData";
+import { getBatchedLogs } from "../lib/getLogs";
 import type { MatchRecord } from "../types";
+
+const matchRecordedEvent = matchProofAbi.find(
+  (e) => e.type === "event" && e.name === "MatchRecorded",
+)!;
 
 export function useMatchEvents() {
   return useQuery({
@@ -11,11 +15,9 @@ export function useMatchEvents() {
     queryFn: async (): Promise<MatchRecord[]> => {
       if (USE_MOCK_DATA) return MOCK_MATCHES;
 
-      const logs = await publicClient.getLogs({
+      const logs = await getBatchedLogs({
         address: CONTRACTS.matchProof,
-        event: matchProofAbi.find((e) => e.type === "event" && e.name === "MatchRecorded")!,
-        fromBlock: 0n,
-        toBlock: "latest",
+        event: matchRecordedEvent,
       });
 
       return logs.map((log) => ({

--- a/web/src/hooks/useWagerEvents.ts
+++ b/web/src/hooks/useWagerEvents.ts
@@ -1,9 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
-import { publicClient } from "../viem";
 import { wagerAbi } from "../abi/wager";
 import { CONTRACTS, USE_MOCK_DATA } from "../config";
 import { MOCK_WAGERS } from "../lib/mockData";
+import { getBatchedLogs } from "../lib/getLogs";
 import type { WagerRecord } from "../types";
+
+const wagerProposedEvent = wagerAbi.find(
+  (e) => e.type === "event" && e.name === "WagerProposed",
+)!;
 
 export function useWagerEvents() {
   return useQuery({
@@ -11,11 +15,9 @@ export function useWagerEvents() {
     queryFn: async (): Promise<WagerRecord[]> => {
       if (USE_MOCK_DATA) return MOCK_WAGERS;
 
-      const logs = await publicClient.getLogs({
+      const logs = await getBatchedLogs({
         address: CONTRACTS.wager,
-        event: wagerAbi.find((e) => e.type === "event" && e.name === "WagerProposed")!,
-        fromBlock: 0n,
-        toBlock: "latest",
+        event: wagerProposedEvent,
       });
 
       return logs.map((log) => ({

--- a/web/src/lib/getLogs.ts
+++ b/web/src/lib/getLogs.ts
@@ -1,0 +1,32 @@
+import type { AbiEvent } from "viem";
+import { publicClient } from "../viem";
+import { DEPLOY_BLOCK, MAX_LOG_RANGE } from "../config";
+
+/**
+ * Batched getLogs — Monad testnet limits to 100 blocks per request.
+ * Scans from DEPLOY_BLOCK to latest in chunks.
+ */
+export async function getBatchedLogs({
+  address,
+  event,
+}: {
+  address: `0x${string}`;
+  event: AbiEvent;
+}) {
+  const latest = await publicClient.getBlockNumber();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const logs: any[] = [];
+
+  for (let from = DEPLOY_BLOCK; from <= latest; from += MAX_LOG_RANGE) {
+    const to = from + MAX_LOG_RANGE - 1n > latest ? latest : from + MAX_LOG_RANGE - 1n;
+    const batch = await publicClient.getLogs({
+      address,
+      event,
+      fromBlock: from,
+      toBlock: to,
+    });
+    logs.push(...batch);
+  }
+
+  return logs;
+}


### PR DESCRIPTION
## Summary

- Monad testnet RPC returns HTTP 413 for `eth_getLogs` spanning more than 100 blocks
- Adds `getBatchedLogs` helper that scans from deploy block to latest in 100-block chunks
- Both `useMatchEvents` and `useWagerEvents` hooks now use the batched helper
- Adds `web/.vite/` to `.gitignore`

Verified: both of Scav's test `recordMatch()` transactions show up correctly on the live site.

## Test plan

- [ ] `VITE_USE_MOCK_DATA=false npm run dev` — site loads real events from testnet
- [ ] Leaderboard and match history show Scav's two test matches
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)