### PR TITLE
Add CRT aesthetic and live arena status

### DIFF
--- a/web/src/components/landing/Hero.tsx
+++ b/web/src/components/landing/Hero.tsx
@@ -1,16 +1,71 @@
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { useArenaHealth } from "../../hooks/useArenaHealth";
+
+function ArenaStatus({ onSignalChange }: { onSignalChange: () => void }) {
+  const { data: health } = useArenaHealth();
+  const prev = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!health) return;
+    const sig = `${health.active_matches}:${health.agents_in_queue}:${health.matches_played}`;
+    if (prev.current !== null && prev.current !== sig) {
+      onSignalChange();
+    }
+    prev.current = sig;
+  }, [health, onSignalChange]);
+
+  if (!health) return null;
+
+  const hasActivity = health.active_matches > 0 || health.agents_in_queue > 0;
+
+  return (
+    <div className="mt-8 inline-flex items-center gap-3 bg-surface-800/80 border border-surface-600 rounded-full px-5 py-2 text-sm font-mono">
+      <span
+        className={`inline-block w-2 h-2 rounded-full ${hasActivity ? "bg-accent-green live-dot" : "bg-gray-500"}`}
+      />
+      {hasActivity ? (
+        <span className="text-gray-300">
+          {health.active_matches > 0 && (
+            <span className="text-accent-green">{health.active_matches} match{health.active_matches !== 1 ? "es" : ""} live</span>
+          )}
+          {health.active_matches > 0 && health.agents_in_queue > 0 && (
+            <span className="text-gray-500"> / </span>
+          )}
+          {health.agents_in_queue > 0 && (
+            <span className="text-gray-400">{health.agents_in_queue} in queue</span>
+          )}
+        </span>
+      ) : (
+        <span className="text-gray-500">Arena idle</span>
+      )}
+    </div>
+  );
+}
 
 export function Hero() {
+  const [burst, setBurst] = useState(false);
+
+  const handleSignalChange = useRef(() => {
+    setBurst(true);
+  }).current;
+
   return (
-    <section className="py-24 text-center">
-      <h1 className="font-mono font-bold text-6xl md:text-8xl tracking-tighter">
-        <span className="text-accent-green">NO</span>{" "}
+    <section className="py-24 text-center crt-scanlines">
+      <h1
+        className={`font-mono font-bold text-6xl md:text-8xl tracking-tighter crt-flicker ${burst ? "crt-burst" : ""}`}
+        onAnimationEnd={(e) => {
+          if (e.animationName === "crt-burst") setBurst(false);
+        }}
+      >
+        <span className="text-accent-green phosphor-glow">NO</span>{" "}
         <span className="text-white">JOHNS</span>
       </h1>
       <p className="mt-6 text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed">
         Autonomous agents compete in skill-based games. Results are verified onchain.
         No excuses.
       </p>
+      <ArenaStatus onSignalChange={handleSignalChange} />
       <div className="mt-10 flex gap-4 justify-center">
         <Link
           to="/compete"

--- a/web/src/hooks/useArenaHealth.ts
+++ b/web/src/hooks/useArenaHealth.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { ARENA_URL } from "../config";
+
+interface ArenaHealth {
+  status: string;
+  matches_played: number;
+  agents_in_queue: number;
+  active_matches: number;
+}
+
+export function useArenaHealth() {
+  return useQuery({
+    queryKey: ["arenaHealth"],
+    queryFn: async (): Promise<ArenaHealth | null> => {
+      try {
+        const res = await fetch(`${ARENA_URL}/health`);
+        if (!res.ok) return null;
+        return await res.json();
+      } catch {
+        return null;
+      }
+    },
+    refetchInterval: 5000,
+    staleTime: 3000,
+    retry: false,
+  });
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -19,3 +19,65 @@
     @apply bg-surface-600 rounded-full;
   }
 }
+
+/* CRT scanline overlay */
+.crt-scanlines {
+  position: relative;
+}
+
+.crt-scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 3px,
+    rgba(0, 0, 0, 0.04) 3px,
+    rgba(0, 0, 0, 0.04) 6px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Phosphor glow on green text */
+.phosphor-glow {
+  text-shadow:
+    0 0 8px rgba(74, 222, 128, 0.2),
+    0 0 25px rgba(74, 222, 128, 0.07);
+}
+
+/* Subtle flicker animation */
+@keyframes crt-flicker {
+  0%, 100% { opacity: 1; }
+  42% { opacity: 0.99; }
+  58% { opacity: 0.995; }
+}
+
+.crt-flicker {
+  animation: crt-flicker 7s ease-in-out infinite;
+}
+
+/* Signal-change burst — brief hard flicker then settle */
+@keyframes crt-burst {
+  0% { opacity: 1; }
+  8% { opacity: 0.7; }
+  16% { opacity: 0.95; }
+  24% { opacity: 0.8; }
+  40% { opacity: 1; }
+  100% { opacity: 1; }
+}
+
+.crt-burst {
+  animation: crt-burst 0.3s ease-out forwards;
+}
+
+/* Pulsing dot for live indicator */
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.live-dot {
+  animation: pulse-dot 2s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary
- Subtle CRT effects on hero section: scanline overlay, phosphor glow on green text, ambient flicker
- Live arena status indicator polls `GET /health` every 5s, shows active matches and queue count
- Signal-change burst flicker when arena numbers update

## Test plan
- [ ] `npm run build` passes
- [ ] Dev server renders hero with subtle scanline/glow effects
- [ ] Arena status shows when arena is reachable, hidden when offline
- [ ] Title flickers briefly when polled numbers change

🤖 Generated with [Claude Code](https://claude.com/claude-code)