### PR TITLE
Autonomous wager negotiation — no interactive prompts

### DIFF
--- a/nojohns/config.py
+++ b/nojohns/config.py
@@ -77,6 +77,7 @@ class GameConfig:
     online_delay: int | None = None
     input_throttle: int | None = None
     replay_dir: str | None = None  # Where to save Slippi replays
+    wager_amount: float | None = None  # MON per match (auto-wager)
 
 
 @dataclass
@@ -144,6 +145,7 @@ def _parse_game_config(data: dict) -> GameConfig:
         online_delay=data.get("online_delay"),
         input_throttle=data.get("input_throttle"),
         replay_dir=_expand(data.get("replay_dir")),
+        wager_amount=data.get("wager_amount"),
     )
 
 


### PR DESCRIPTION
## Summary

- Adds `--wager AMOUNT` flag to `matchmake` + `wager_amount` config option
- Removes all `input()` calls from `_negotiate_wager()` and `_respond_to_wager()`
- No flag/config = skip wagering silently (zero prompts, zero polling delay)
- Auto-propose our amount, auto-accept opponent proposals ≤ our max, auto-decline if higher

## Behavior

| Scenario | Result |
|----------|--------|
| `--wager 0.1` | Propose 0.1 MON, accept ≤ 0.1, decline > 0.1 |
| `--wager 0.1` + opponent proposes 0.05 | Accept theirs |
| `--wager 0.1` + opponent proposes 0.5 | Decline, play without stakes |
| No flag, no config | Skip wagering entirely |

## Files changed

- `nojohns/config.py` — `wager_amount` field on `GameConfig`
- `nojohns/cli.py` — `--wager` flag, `_resolve_args()`, rewritten `_negotiate_wager()` + `_respond_to_wager()`

## Test plan

- [x] `pytest tests/ -v` — 122 passed
- [ ] `nojohns matchmake phillip --wager 0.1` — auto-propose and auto-accept
- [ ] `nojohns matchmake phillip` (no flag) — skip wagering silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)