### PR TITLE
Wire PredictionPool into arena + CLI

### DIFF
--- a/nojohns/cli.py
+++ b/nojohns/cli.py
@@ -1019,8 +1019,8 @@ def _try_record_onchain(match_id, match_result, nj_cfg, account, _get):
         print(f" confirmed!")
         print(f"  tx: 0x{tx_hash}")
 
-        # Post Elo update to ReputationRegistry
-        _post_elo_update(match_result, nj_cfg, account)
+        # NOTE: Elo updates are posted by the arena server (not the player).
+        # ERC-8004 blocks self-feedback, so the agent wallet can't post its own Elo.
 
         # Resolve prediction pool (if one exists for this match)
         _try_resolve_pool(match_id, nj_cfg, account)
@@ -1038,74 +1038,6 @@ def _try_record_onchain(match_id, match_result, nj_cfg, account, _get):
             pass
         logger.warning(f"Failed to record match onchain: {e}")
         print(f" failed: {e}")
-
-
-def _post_elo_update(match_result: dict, config, account):
-    """Post Elo update to ReputationRegistry after match."""
-    if config.chain is None or config.chain.reputation_registry is None:
-        logger.debug("No reputation registry configured — skipping Elo posting")
-        return
-    if config.chain.agent_id is None:
-        logger.debug("No agent_id configured — skipping Elo posting")
-        return
-
-    try:
-        from nojohns.reputation import (
-            get_current_elo,
-            calculate_new_elo,
-            post_elo_update,
-            STARTING_ELO,
-        )
-    except ImportError:
-        logger.debug("reputation module not available")
-        return
-
-    # Determine if we won
-    our_address = account.address.lower()
-    winner_address = match_result["winner"].lower()
-    we_won = our_address == winner_address
-
-    # Get current Elo
-    current = get_current_elo(
-        config.chain.agent_id,
-        config.chain.rpc_url,
-        config.chain.reputation_registry,
-    )
-
-    # For opponent Elo, use default (we don't know their agent_id easily)
-    # TODO: look up opponent's agent_id from IdentityRegistry by wallet
-    opponent_elo = STARTING_ELO
-
-    # Calculate new Elo
-    new_elo = calculate_new_elo(current.elo, opponent_elo, we_won)
-    peak_elo = max(current.peak_elo, new_elo)
-
-    # Update record
-    if we_won:
-        wins = current.wins + 1
-        losses = current.losses
-    else:
-        wins = current.wins
-        losses = current.losses + 1
-    record = f"{wins}-{losses}"
-
-    print(f"  Posting Elo update: {current.elo} → {new_elo} ({'+' if we_won else ''}{new_elo - current.elo})")
-
-    tx_hash = post_elo_update(
-        config.chain.agent_id,
-        new_elo,
-        peak_elo,
-        record,
-        account,
-        config.chain.rpc_url,
-        config.chain.reputation_registry,
-        config.chain.chain_id,
-    )
-
-    if tx_hash:
-        print(f"  Elo tx: 0x{tx_hash}")
-    else:
-        print("  Elo update failed (non-critical)")
 
 
 def _try_resolve_pool(match_id: str, config, account):

--- a/nojohns/config.py
+++ b/nojohns/config.py
@@ -100,6 +100,7 @@ class ChainConfig:
     rpc_url: str = "https://testnet-rpc.monad.xyz"
     match_proof: str | None = None  # MatchProof contract address
     wager: str | None = None  # Wager contract address
+    prediction_pool: str | None = None  # PredictionPool contract address
     # ERC-8004 registries (deployed singletons)
     identity_registry: str | None = None  # IdentityRegistry address
     reputation_registry: str | None = None  # ReputationRegistry address
@@ -216,6 +217,7 @@ def load_config(path: Path | None = None) -> NojohnsConfig:
             rpc_url=chain_data.get("rpc_url", "https://testnet-rpc.monad.xyz"),
             match_proof=chain_data.get("match_proof"),
             wager=chain_data.get("wager"),
+            prediction_pool=chain_data.get("prediction_pool"),
             identity_registry=chain_data.get("identity_registry"),
             reputation_registry=chain_data.get("reputation_registry"),
             agent_id=chain_data.get("agent_id"),


### PR DESCRIPTION
## Summary

- **contract.py**: PredictionPool ABI + `create_pool()`, `resolve_pool()`, `cancel_pool()` functions (same pattern as `record_match()`)
- **arena/server.py**: Arena creates pools on match creation, cancels on expiry. New `GET /matches/{id}/pool` endpoint for frontend. New `PREDICTION_POOL` env var.
- **arena/db.py**: `pool_id` column on matches table, `expire_stale_matches()` now returns match IDs (for pool cancellation)
- **nojohns/cli.py**: `_try_resolve_pool()` called after successful `recordMatch()` — reads pool_id from arena, resolves onchain
- **nojohns/config.py**: `prediction_pool` field on `ChainConfig`

### Disconnect handling

| Scenario | Pool Created? | Pool Resolved? | Pool Cancelled? | Bettor Experience |
|----------|--------------|----------------|-----------------|-------------------|
| Clean match | Yes | Yes (after recordMatch) | No | Instant payout |
| Disconnect | Yes | No | Yes (arena expiry, ≤30min) | Refund within 30min |
| Never connects | Yes | No | Yes (arena expiry, ≤30min) | Refund within 30min |
| Arena down | Yes | No | Yes (cancelStalePool, ≤2hr) | Refund within 2hr (safety net) |

All silently skips when `PREDICTION_POOL` / arena wallet not configured — no impact on tier 1 operators.

## Test plan

- [x] 166 existing tests pass, no regressions
- [ ] Deploy PredictionPool contract (ScavieFae), set `PREDICTION_POOL` env var on arena
- [ ] Run a match with pool creation enabled, verify pool_id stored in DB
- [ ] Verify `GET /matches/{id}/pool` returns correct pool_id
- [ ] Verify pool resolves after `recordMatch()` succeeds
- [ ] Verify pool cancels when match expires (kill Dolphin mid-match, wait for expiry sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)